### PR TITLE
Fix for wipedev missing slot 1-1

### DIFF
--- a/src/fakeroot/opt/45drives/tools/wipedev
+++ b/src/fakeroot/opt/45drives/tools/wipedev
@@ -54,7 +54,7 @@ fi
 if [ $ALL_FLAG -eq 1 ];then
 	BAYS=$((cat $CONFIG_PATH/vdev_id.conf| awk "NR>1" | wc -l) 2>/dev/null)
 	i=0
-	j=3
+	j=2
 	## LOOP THROUGH BAYS
 	while [ "$i" -lt $BAYS ];do
 		bay=$(cat $CONFIG_PATH/vdev_id.conf | awk -v j=$j 'NR==j{print $2}')


### PR DESCRIPTION
Change initial value of "j" from 3 to 2 in order to conform to the newer format of vdev_id.conf generated by dmap. This should stop the script from skipping the first slot.