### PR TITLE
adds function to get actual ata port path for romed8-2t sata controllers

### DIFF
--- a/tools/dmap
+++ b/tools/dmap
@@ -892,52 +892,90 @@ def alias_hl8():
 
 
 ###############################################################################
+# Helper: list existing /dev/disk/by-path entries for a SATA controller
+# - Dedupes ".0" variants (prefers the base "-ata-N" if both exist)
+# - Returns a list of full paths sorted by numeric port (ascending)
+###############################################################################
+def list_ata_port_paths(pci_addr):
+    pattern = f"/dev/disk/by-path/pci-{pci_addr}-ata-*"
+    paths = glob.glob(pattern)
+    # Keep only names that end with -ata-N or -ata-N.0 and extract N
+    rx = re.compile(rf"/dev/disk/by-path/pci-{re.escape(pci_addr)}-ata-(\d+)(?:\.0)?$")
+    best_by_port = {}
+    for p in paths:
+        m = rx.match(p)
+        if not m:
+            continue
+        n = int(m.group(1))
+        # Prefer base link without ".0" when both exist
+        if n not in best_by_port:
+            best_by_port[n] = p
+        else:
+            if best_by_port[n].endswith(".0") and not p.endswith(".0"):
+                best_by_port[n] = p
+    # Sort by port number
+    return [best_by_port[n] for n in sorted(best_by_port)]
+
+
+###############################################################################
 # Name: alias_hl15_beast_romed8
 # Args: server, phy_order
 # Desc: HL15_BEAST mapping for ROMED8-2T:
 #       - First 15 drives on the single HBA (deterministic SAS phy order)
-#       - Last 8 drives (16..23) on onboard SATA: 4 on the first controller
-#         as ata-1..4, and 4 on the second controller as ata-1..4.
-#       Assumes /dev/disk/by-path naming with -ata-* like other SATA helpers.
+#       - Last 8 drives (16..23) on onboard SATA discovered from actual by-path
 ###############################################################################
 def alias_hl15_beast_romed8(server, phy_order):
-	if not server.get("HBA"):
-		log("!! ERROR !! No HBA found for HL15_BEAST (ROMED8-2T path)")
-		sys.exit(1)
-	hba = server["HBA"][0]
-	model = hba.get("Model", "")
-	bus   = hba.get("Bus Address", "")
-	if model in ["9600-24i", "9600-16i", "9361-16i", "9361-24i"]:
-		log("!! ERROR !! Unexpected HBA model for HL15_BEAST (ROMED8-2T path): {m}".format(m=model))
-		sys.exit(1)
-	if model not in phy_order:
-		log("!! ERROR !! Unknown HBA model '{m}' for HL15_BEAST (ROMED8-2T path)".format(m=model))
-		sys.exit(1)
+    if not server.get("HBA"):
+        log("!! ERROR !! No HBA found for HL15_BEAST (ROMED8-2T path)")
+        sys.exit(1)
+    hba = server["HBA"][0]
+    model = hba.get("Model", "")
+    bus   = hba.get("Bus Address", "")
+    if model in ["9600-24i", "9600-16i", "9361-16i", "9361-24i"]:
+        log("!! ERROR !! Unexpected HBA model for HL15_BEAST (ROMED8-2T path): {m}".format(m=model))
+        sys.exit(1)
+    if model not in phy_order:
+        log("!! ERROR !! Unknown HBA model '{m}' for HL15_BEAST (ROMED8-2T path)".format(m=model))
+        sys.exit(1)
 
-	vdev_id_str = ""
-	# 1) First 15 bays via HBA
-	for j in range(15):
-		p = phy_order[model][j]
-		vdev_id_str += "alias 1-{idx} /dev/disk/by-path/pci-{addr}-sas-phy{phy}-lun-0\n".format(
-			idx=j+1, addr=bus, phy=p)
+    vdev_id_str = ""
+    # 1) First 15 bays via HBA
+    for j in range(15):
+        p = phy_order[model][j]
+        vdev_id_str += "alias 1-{idx} /dev/disk/by-path/pci-{addr}-sas-phy{phy}-lun-0\n".format(
+            idx=j+1, addr=bus, phy=p)
 
-	# 2) Last 8 bays via onboard SATA (two controllers)
-	sata_addrs = get_sata_pci_addresses()
-	if len(sata_addrs) < 2:
-		log("!! ERROR !! Expected at least two SATA controllers on ROMED8-2T, found {n}".format(n=len(sata_addrs)))
-		sys.exit(1)
-	sata0, sata1 = sata_addrs[0], sata_addrs[1]
+    # 2) Last 8 bays via onboard SATA (two controllers)
+    sata_addrs = get_sata_pci_addresses()
+    if len(sata_addrs) < 2:
+        log("!! ERROR !! Expected at least two SATA controllers on ROMED8-2T, found {n}".format(n=len(sata_addrs)))
+        sys.exit(1)
 
-	# Map drives 16..19 from sata0 as ata-1..4
-	for k in range(4):
-		vdev_id_str += "alias 1-{idx} /dev/disk/by-path/pci-0000:{addr}-ata-{port}\n".format(
-			idx=16+k, addr=sata0, port=k+1)
-	# Map drives 20..23 from sata1 as ata-1..4
-	for k in range(4):
-		vdev_id_str += "alias 1-{idx} /dev/disk/by-path/pci-0000:{addr}-ata-{port}\n".format(
-			idx=20+k, addr=sata1, port=k+1)
+    sata0, sata1 = sata_addrs[0], sata_addrs[1]
 
-	return vdev_id_str
+    # Discover real by-path suffixes for each controller
+    sata0_paths = list_ata_port_paths(sata0)
+    sata1_paths = list_ata_port_paths(sata1)
+
+    # Require at least 4 usable ports per controller
+    if len(sata0_paths) < 4:
+        log("!! ERROR !! Controller {a} exposes only {n} ata ports under /dev/disk/by-path. Need >= 4. Found: {lst}".format(
+            a=sata0, n=len(sata0_paths), lst=", ".join(os.path.basename(p) for p in sata0_paths)))
+        sys.exit(1)
+    if len(sata1_paths) < 4:
+        log("!! ERROR !! Controller {a} exposes only {n} ata ports under /dev/disk/by-path. Need >= 4. Found: {lst}".format(
+            a=sata1, n=len(sata1_paths), lst=", ".join(os.path.basename(p) for p in sata1_paths)))
+        sys.exit(1)
+
+    # Map drives 16..19 from the first 4 discovered ports on sata0
+    for i, path in enumerate(sata0_paths[:4], start=16):
+        vdev_id_str += "alias 1-{idx} {path}\n".format(idx=i, path=path)
+
+    # Map drives 20..23 from the first 4 discovered ports on sata1
+    for i, path in enumerate(sata1_paths[:4], start=20):
+        vdev_id_str += "alias 1-{idx} {path}\n".format(idx=i, path=path)
+
+    return vdev_id_str
 
 ###############################################################################
 # Name: alias_pro4
@@ -1219,7 +1257,7 @@ def main():
 
 	server = get_server_info()
 	
-	if server["Model"] is "HomeLab-HL15":
+	if server["Model"] == "HomeLab-HL15":
 		log("dmap is not compatible with HomeLab-HL15 Servers. You can perform device mapping manually using 'dalias'")
 		log("Try running: 'sudo dalias -t HL15'")
 		sys.exit(1)

--- a/tools/dmap
+++ b/tools/dmap
@@ -923,6 +923,10 @@ def list_ata_port_paths(pci_addr):
 # Desc: HL15_BEAST mapping for ROMED8-2T:
 #       - First 15 drives on the single HBA (deterministic SAS phy order)
 #       - Last 8 drives (16..23) on onboard SATA discovered from actual by-path
+# Extra:
+#   - Warns/exits if no SSDs are detected on onboard SATA (cannot infer block)
+#   - Detects the base block (1–4 or 5–8) from the first SSD it sees and
+#     applies that block to BOTH controllers.
 ###############################################################################
 def alias_hl15_beast_romed8(server, phy_order):
     if not server.get("HBA"):
@@ -931,13 +935,15 @@ def alias_hl15_beast_romed8(server, phy_order):
     hba = server["HBA"][0]
     model = hba.get("Model", "")
     bus   = hba.get("Bus Address", "")
-    if model in ["9600-24i", "9600-16i", "9361-16i", "9361-24i"]:
-        log("!! ERROR !! Unexpected HBA model for HL15_BEAST (ROMED8-2T path): {m}".format(m=model))
-        sys.exit(1)
-    if model not in phy_order:
-        log("!! ERROR !! Unknown HBA model '{m}' for HL15_BEAST (ROMED8-2T path)".format(m=model))
-        sys.exit(1)
 
+	# expected_hba_model = ["9600-24i", "9600-16i", "9361-16i", "9361-24i"]
+    # if model not in [expected_hba_model]:
+    #     log("!! ERROR !! Unexpected HBA model for HL15_BEAST (ROMED8-2T path): {m}".format(m=model))
+    #     sys.exit(1)
+    # if model not in phy_order:
+    #     log("!! ERROR !! Unknown HBA model '{m}' for HL15_BEAST (ROMED8-2T path)".format(m=model))
+    #     sys.exit(1)
+    
     vdev_id_str = ""
     # 1) First 15 bays via HBA
     for j in range(15):
@@ -957,25 +963,59 @@ def alias_hl15_beast_romed8(server, phy_order):
     sata0_paths = list_ata_port_paths(sata0)
     sata1_paths = list_ata_port_paths(sata1)
 
-    # Require at least 4 usable ports per controller
-    if len(sata0_paths) < 4:
-        log("!! ERROR !! Controller {a} exposes only {n} ata ports under /dev/disk/by-path. Need >= 4. Found: {lst}".format(
-            a=sata0, n=len(sata0_paths), lst=", ".join(os.path.basename(p) for p in sata0_paths)))
-        sys.exit(1)
-    if len(sata1_paths) < 4:
-        log("!! ERROR !! Controller {a} exposes only {n} ata ports under /dev/disk/by-path. Need >= 4. Found: {lst}".format(
-            a=sata1, n=len(sata1_paths), lst=", ".join(os.path.basename(p) for p in sata1_paths)))
+    # At least 1 SSD required overall so we can detect the global block (1–4 or 5–8)
+    combined = sata0_paths + sata1_paths
+    if not combined:
+        log("!! WARNING !! At least 1 SSD must be installed on the onboard SATA to auto-detect port block (1–4 vs 5–8). None found.")
         sys.exit(1)
 
-    # Map drives 16..19 from the first 4 discovered ports on sata0
-    for i, path in enumerate(sata0_paths[:4], start=16):
+    # Determine the block from the first detected SSD path
+    m = re.search(r"-ata-(\d+)(?:\.0)?$", combined[0])
+    if not m:
+        log("!! ERROR !! Unable to parse ATA port from first detected path: {p}".format(p=combined[0]))
+        sys.exit(1)
+    first_n = int(m.group(1))
+    base = 1 if 1 <= first_n <= 4 else 5
+    block = set(range(base, base + 4))
+
+    # Filter each controller to the selected block (keep order by port)
+    def filter_block(paths):
+        kept = []
+        for p in paths:
+            mm = re.search(r"-ata-(\d+)(?:\.0)?$", p)
+            if not mm:
+                continue
+            n = int(mm.group(1))
+            if n in block:
+                kept.append((n, p))
+        kept.sort(key=lambda t: t[0])
+        return [p for _, p in kept]
+
+    sata0_block = filter_block(sata0_paths)
+    sata1_block = filter_block(sata1_paths)
+
+    # Require 4 usable ports per controller within the chosen block
+    if len(sata0_block) < 4:
+        log("!! ERROR !! Controller {a} exposes only {n} ata ports in block {b}-{e}. Need 4. Found: {lst}".format(
+            a=sata0, n=len(sata0_block), b=base, e=base+3,
+            lst=", ".join(os.path.basename(p) for p in sata0_block)))
+        sys.exit(1)
+    if len(sata1_block) < 4:
+        log("!! ERROR !! Controller {a} exposes only {n} ata ports in block {b}-{e}. Need 4. Found: {lst}".format(
+            a=sata1, n=len(sata1_block), b=base, e=base+3,
+            lst=", ".join(os.path.basename(p) for p in sata1_block)))
+        sys.exit(1)
+
+    # Map drives 16..19 from the selected block on sata0
+    for i, path in enumerate(sata0_block[:4], start=16):
         vdev_id_str += "alias 1-{idx} {path}\n".format(idx=i, path=path)
 
-    # Map drives 20..23 from the first 4 discovered ports on sata1
-    for i, path in enumerate(sata1_paths[:4], start=20):
+    # Map drives 20..23 from the selected block on sata1
+    for i, path in enumerate(sata1_block[:4], start=20):
         vdev_id_str += "alias 1-{idx} {path}\n".format(idx=i, path=path)
 
     return vdev_id_str
+
 
 ###############################################################################
 # Name: alias_pro4

--- a/tools/dmap
+++ b/tools/dmap
@@ -936,14 +936,13 @@ def alias_hl15_beast_romed8(server, phy_order):
     model = hba.get("Model", "")
     bus   = hba.get("Bus Address", "")
 
-	# expected_hba_model = ["9600-24i", "9600-16i", "9361-16i", "9361-24i"]
-    # if model not in [expected_hba_model]:
-    #     log("!! ERROR !! Unexpected HBA model for HL15_BEAST (ROMED8-2T path): {m}".format(m=model))
-    #     sys.exit(1)
-    # if model not in phy_order:
-    #     log("!! ERROR !! Unknown HBA model '{m}' for HL15_BEAST (ROMED8-2T path)".format(m=model))
-    #     sys.exit(1)
-    
+    if model not in ["HBA 9400-16i"]:
+        log("!! ERROR !! Unexpected HBA model for HL15_BEAST (ROMED8-2T path): {m}".format(m=model))
+        sys.exit(1)
+    if model not in phy_order:
+        log("!! ERROR !! Unknown HBA model '{m}' for HL15_BEAST (ROMED8-2T path)".format(m=model))
+        sys.exit(1)
+        
     vdev_id_str = ""
     # 1) First 15 bays via HBA
     for j in range(15):

--- a/tools/dmap
+++ b/tools/dmap
@@ -975,36 +975,6 @@ def alias_hl15_beast_romed8(server, phy_order):
 		sys.exit(1)
 	first_n = int(m.group(1))
 	base = 1 if 1 <= first_n <= 4 else 5
-	block = set(range(base, base + 4))
-
-	# Filter each controller to the selected block (keep order by port)
-	def filter_block(paths):
-		kept = []
-		for p in paths:
-			mm = re.search(r"-ata-(\d+)(?:\.0)?$", p)
-			if not mm:
-				continue
-			n = int(mm.group(1))
-			if n in block:
-				kept.append((n, p))
-		kept.sort(key=lambda t: t[0])
-		return [p for _, p in kept]
-
-	sata0_block = filter_block(sata0_paths)
-	sata1_block = filter_block(sata1_paths)
-
-	# Require 4 usable ports per controller within the chosen block
-	if len(sata0_block) < 4:
-		log("!! ERROR !! Controller {a} exposes only {n} ata ports in block {b}-{e}. Need 4. Found: {lst}".format(
-			a=sata0, n=len(sata0_block), b=base, e=base+3,
-			lst=", ".join(os.path.basename(p) for p in sata0_block)))
-		sys.exit(1)
-	if len(sata1_block) < 4:
-		log("!! ERROR !! Controller {a} exposes only {n} ata ports in block {b}-{e}. Need 4. Found: {lst}".format(
-			a=sata1, n=len(sata1_block), b=base, e=base+3,
-			lst=", ".join(os.path.basename(p) for p in sata1_block)))
-		sys.exit(1)
-
 	port_range = range(base, base + 4)
 
 	for i, port in enumerate(port_range, start=16):

--- a/tools/dmap
+++ b/tools/dmap
@@ -929,92 +929,91 @@ def list_ata_port_paths(pci_addr):
 #     applies that block to BOTH controllers.
 ###############################################################################
 def alias_hl15_beast_romed8(server, phy_order):
-    if not server.get("HBA"):
-        log("!! ERROR !! No HBA found for HL15_BEAST (ROMED8-2T path)")
-        sys.exit(1)
-    hba = server["HBA"][0]
-    model = hba.get("Model", "")
-    bus   = hba.get("Bus Address", "")
+	if not server.get("HBA"):
+		log("!! ERROR !! No HBA found for HL15_BEAST (ROMED8-2T path)")
+		sys.exit(1)
+	hba = server["HBA"][0]
+	model = hba.get("Model", "")
+	bus   = hba.get("Bus Address", "")
 
-    if model not in ["HBA 9400-16i"]:
-        log("!! ERROR !! Unexpected HBA model for HL15_BEAST (ROMED8-2T path): {m}".format(m=model))
-        sys.exit(1)
-    if model not in phy_order:
-        log("!! ERROR !! Unknown HBA model '{m}' for HL15_BEAST (ROMED8-2T path)".format(m=model))
-        sys.exit(1)
-        
-    vdev_id_str = ""
-    # 1) First 15 bays via HBA
-    for j in range(15):
-        p = phy_order[model][j]
-        vdev_id_str += "alias 1-{idx} /dev/disk/by-path/pci-{addr}-sas-phy{phy}-lun-0\n".format(
-            idx=j+1, addr=bus, phy=p)
+	if model not in ["HBA 9400-16i"]:
+		log("!! ERROR !! Unexpected HBA model for HL15_BEAST (ROMED8-2T path): {m}".format(m=model))
+		sys.exit(1)
+	if model not in phy_order:
+		log("!! ERROR !! Unknown HBA model '{m}' for HL15_BEAST (ROMED8-2T path)".format(m=model))
+		sys.exit(1)
+		
+	vdev_id_str = ""
+	# 1) First 15 bays via HBA
+	for j in range(15):
+		p = phy_order[model][j]
+		vdev_id_str += "alias 1-{idx} /dev/disk/by-path/pci-{addr}-sas-phy{phy}-lun-0\n".format(
+			idx=j+1, addr=bus, phy=p)
 
-    # 2) Last 8 bays via onboard SATA (two controllers)
-    sata_addrs = get_sata_pci_addresses()
-    if len(sata_addrs) < 2:
-        log("!! ERROR !! Expected at least two SATA controllers on ROMED8-2T, found {n}".format(n=len(sata_addrs)))
-        sys.exit(1)
+	# 2) Last 8 bays via onboard SATA (two controllers)
+	sata_addrs = get_sata_pci_addresses()
+	if len(sata_addrs) < 2:
+		log("!! ERROR !! Expected at least two SATA controllers on ROMED8-2T, found {n}".format(n=len(sata_addrs)))
+		sys.exit(1)
 
-    sata0, sata1 = sata_addrs[0], sata_addrs[1]
+	sata0, sata1 = sata_addrs[0], sata_addrs[1]
 
-    # Discover real by-path suffixes for each controller
-    sata0_paths = list_ata_port_paths(sata0)
-    sata1_paths = list_ata_port_paths(sata1)
+	# Discover real by-path suffixes for each controller
+	sata0_paths = list_ata_port_paths(sata0)
+	sata1_paths = list_ata_port_paths(sata1)
 
-    # At least 1 SSD required overall so we can detect the global block (1–4 or 5–8)
-    combined = sata0_paths + sata1_paths
-    if not combined:
-        log("!! WARNING !! At least 1 SSD must be installed on the onboard SATA to auto-detect port block (1–4 vs 5–8). None found.")
-        sys.exit(1)
+	# At least 1 SSD required overall so we can detect the global block (1–4 or 5–8)
+	combined = sata0_paths + sata1_paths
+	if not combined:
+		log("!! WARNING !! At least 1 SSD must be installed on the onboard SATA to auto-detect port block (1–4 vs 5–8). None found.")
+		sys.exit(1)
 
-    # Determine the block from the first detected SSD path
-    m = re.search(r"-ata-(\d+)(?:\.0)?$", combined[0])
-    if not m:
-        log("!! ERROR !! Unable to parse ATA port from first detected path: {p}".format(p=combined[0]))
-        sys.exit(1)
-    first_n = int(m.group(1))
-    base = 1 if 1 <= first_n <= 4 else 5
-    block = set(range(base, base + 4))
+	# Determine the block from the first detected SSD path
+	m = re.search(r"-ata-(\d+)(?:\.0)?$", combined[0])
+	if not m:
+		log("!! ERROR !! Unable to parse ATA port from first detected path: {p}".format(p=combined[0]))
+		sys.exit(1)
+	first_n = int(m.group(1))
+	base = 1 if 1 <= first_n <= 4 else 5
+	block = set(range(base, base + 4))
 
-    # Filter each controller to the selected block (keep order by port)
-    def filter_block(paths):
-        kept = []
-        for p in paths:
-            mm = re.search(r"-ata-(\d+)(?:\.0)?$", p)
-            if not mm:
-                continue
-            n = int(mm.group(1))
-            if n in block:
-                kept.append((n, p))
-        kept.sort(key=lambda t: t[0])
-        return [p for _, p in kept]
+	# Filter each controller to the selected block (keep order by port)
+	def filter_block(paths):
+		kept = []
+		for p in paths:
+			mm = re.search(r"-ata-(\d+)(?:\.0)?$", p)
+			if not mm:
+				continue
+			n = int(mm.group(1))
+			if n in block:
+				kept.append((n, p))
+		kept.sort(key=lambda t: t[0])
+		return [p for _, p in kept]
 
-    sata0_block = filter_block(sata0_paths)
-    sata1_block = filter_block(sata1_paths)
+	sata0_block = filter_block(sata0_paths)
+	sata1_block = filter_block(sata1_paths)
 
-    # Require 4 usable ports per controller within the chosen block
-    if len(sata0_block) < 4:
-        log("!! ERROR !! Controller {a} exposes only {n} ata ports in block {b}-{e}. Need 4. Found: {lst}".format(
-            a=sata0, n=len(sata0_block), b=base, e=base+3,
-            lst=", ".join(os.path.basename(p) for p in sata0_block)))
-        sys.exit(1)
-    if len(sata1_block) < 4:
-        log("!! ERROR !! Controller {a} exposes only {n} ata ports in block {b}-{e}. Need 4. Found: {lst}".format(
-            a=sata1, n=len(sata1_block), b=base, e=base+3,
-            lst=", ".join(os.path.basename(p) for p in sata1_block)))
-        sys.exit(1)
+	# Require 4 usable ports per controller within the chosen block
+	if len(sata0_block) < 4:
+		log("!! ERROR !! Controller {a} exposes only {n} ata ports in block {b}-{e}. Need 4. Found: {lst}".format(
+			a=sata0, n=len(sata0_block), b=base, e=base+3,
+			lst=", ".join(os.path.basename(p) for p in sata0_block)))
+		sys.exit(1)
+	if len(sata1_block) < 4:
+		log("!! ERROR !! Controller {a} exposes only {n} ata ports in block {b}-{e}. Need 4. Found: {lst}".format(
+			a=sata1, n=len(sata1_block), b=base, e=base+3,
+			lst=", ".join(os.path.basename(p) for p in sata1_block)))
+		sys.exit(1)
 
-    # Map drives 16..19 from the selected block on sata0
-    for i, path in enumerate(sata0_block[:4], start=16):
-        vdev_id_str += "alias 1-{idx} {path}\n".format(idx=i, path=path)
+	port_range = range(base, base + 4)
 
-    # Map drives 20..23 from the selected block on sata1
-    for i, path in enumerate(sata1_block[:4], start=20):
-        vdev_id_str += "alias 1-{idx} {path}\n".format(idx=i, path=path)
+	for i, port in enumerate(port_range, start=16):
+		vdev_id_str += f"alias 1-{i} /dev/disk/by-path/pci-{sata0}-ata-{port}"
 
-    return vdev_id_str
+	for i, port in enumerate(port_range, start=20):
+		vdev_id_str += f"alias 1-{i} /dev/disk/by-path/pci-{sata1}-ata-{port}"
 
+	return vdev_id_str
 
 ###############################################################################
 # Name: alias_pro4


### PR DESCRIPTION
With HL15 BEAST using ROMED8-2T board, the sata address's ports were being set within the range of 1-4:
eg:
```
alias 1-16 /dev/disk/by-path/pci-0000:48:00.0-ata-1
alias 1-17 /dev/disk/by-path/pci-0000:48:00.0-ata-2
alias 1-18 /dev/disk/by-path/pci-0000:48:00.0-ata-3
alias 1-19 /dev/disk/by-path/pci-0000:48:00.0-ata-4
```
but this was not always the case, if the actual addresses were reporting as 5-8 then the resulting vdev_id.conf created would not match the actual addresses and therefore break lsdev. 

Added a function to check the actual port paths and use them instead of assuming always 1-4.